### PR TITLE
Azuresql

### DIFF
--- a/lib/service.rb
+++ b/lib/service.rb
@@ -43,6 +43,12 @@ Cuba.define do
       tbl = ActiveRecord::Base.connection.tables
               .find { |t| t == table }
 
+      if tbl.nil?
+        res.status = 404
+        res.write("Table #{table} not found")
+        halt(res.finish)
+      end
+
       qs = URI.unescape(env['QUERY_STRING'])
       qp = Parser.parse_qs(qs)
       is_preview =  qs.end_with?('&preview')

--- a/lib/service.rb
+++ b/lib/service.rb
@@ -10,6 +10,7 @@ require 'activerecord-jdbc-adapter'
 require_relative './parser'
 require_relative './interpreter'
 
+require 'sqljdbc4.jar'
 
 ActiveRecord::Base.establish_connection(
 # SQL Lite:
@@ -17,11 +18,11 @@ ActiveRecord::Base.establish_connection(
 #  database: File.join(File.dirname(__FILE__), '..', 'db', 'medals.db')
 
   driver: 'com.microsoft.sqlserver.jdbc.SQLServerDriver',
-  adapter: "sqlserver",
+  adapter: "jdbc",
   host: "thegamma-sql-data.database.windows.net",
-  database: "thegamma-sql-data",
   username: "<secret>",
   password: "<secret>"
+  url: 'jdbc:sqlserver://thegamma-sql-data.database.windows.net:1433;databaseName=thegamma-sql-data',
 )
 
 TYPE_MAP = {


### PR DESCRIPTION
This doesn't solve the `take`/`skip` issue, but should fix the classpath stuff. AFAICT, you won't need to extract the SQLServer diver to another folder to run the service.

Additionally, I added a guard to properly return a 404 if a table can't be found in the DB.